### PR TITLE
fix(qualify_multi) 指定 uid 但未能计算统计量和 P 值

### DIFF
--- a/gbk/qualify.sas
+++ b/gbk/qualify.sas
@@ -22,6 +22,7 @@ Version Date: 2023-03-08 1.0.1
               2024-05-31 1.0.17
               2024-06-03 1.0.18
               2024-06-04 1.0.19
+              2024-06-13 1.0.20
 ===================================
 */
 
@@ -744,10 +745,7 @@ Version Date: 2023-03-08 1.0.1
         proc datasets noprint nowarn;
             delete tmp_qualify_indata
                    tmp_qualify_indata_unique_total
-                   %if %sysmexecdepth < 2 %then %do;
-                       tmp_qualify_indata_unique_var
-                   %end;
-                   %else %if not (%sysmexecname(%sysmexecdepth - 2) = QUALIFY_MULTI_TEST) %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique_var*/
+                   %if not (%sysmexecname(%sysmexecdepth - 2) = QUALIFY_MULTI_TEST) %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique_var*/
                        tmp_qualify_indata_unique_var
                    %end;
                    tmp_qualify_by_fmt

--- a/gbk/qualify_multi.sas
+++ b/gbk/qualify_multi.sas
@@ -11,6 +11,7 @@ Version Date: 2023-12-26 0.1
               2024-04-25 0.6
               2024-04-25 0.7
               2024-06-04 0.8
+              2024-06-13 0.9
 ===================================
 */
 
@@ -303,10 +304,10 @@ Version Date: 2023-12-26 0.1
         %goto exit_with_error;
     %end;
 
-    %if %sysmexecname(%sysmexecdepth - 1) = QUALIFY_MULTI_TEST %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique*/
+    %if %sysmexecname(%sysmexecdepth - 1) = QUALIFY_MULTI_TEST %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique_var*/
         proc datasets library = work noprint nowarn;
-            delete tmp_qmt_indata_unique;
-            change tmp_qualify_indata_unique = tmp_qmt_indata_unique;
+            delete tmp_qmt_indata_unique_var;
+            change tmp_qualify_indata_unique_var = tmp_qmt_indata_unique_var;
         quit;
     %end;
 

--- a/gbk/qualify_multi_test.sas
+++ b/gbk/qualify_multi_test.sas
@@ -11,6 +11,7 @@ Version Date: 2024-01-08 0.1
               2024-04-28 0.6
               2024-06-03 0.7
               2024-06-04 0.8
+              2024-06-13 0.9
 ===================================
 */
 
@@ -289,7 +290,7 @@ Version Date: 2024-01-08 0.1
     %end;
 
     /*卡方和Fisher精确检验*/
-    proc freq data = tmp_qualify_indata_unique_var noprint;
+    proc freq data = tmp_qmt_indata_unique_var noprint;
         tables &var_name*&group_var /chisq(warn = (output nolog)) fisher;
         output out = tmp_qmt_chisq chisq;
     run;
@@ -374,13 +375,13 @@ Version Date: 2024-01-08 0.1
     %if &DEL_TEMP_DATA = TRUE %then %do;
         proc datasets noprint nowarn;
             delete tmp_qmt_indata
-                   tmp_qmt_indata_unique
+                   tmp_qmt_indata_unique_var
                    tmp_qmt_desc
                    tmp_qmt_stat
                    tmp_qmt_outdata
                    tmp_qmt_chisq
 
-                   tmp_qualify_indata_unique /*%qualify_multi 拆分 group 各水平调用 %qualify 残留的数据集*/
+                   tmp_qualify_indata_unique_var /*%qualify_multi 拆分 group 各水平调用 %qualify 残留的数据集*/
                    ;
         quit;
     %end;

--- a/utf8/qualify.sas
+++ b/utf8/qualify.sas
@@ -22,6 +22,7 @@ Version Date: 2023-03-08 1.0.1
               2024-05-31 1.0.17
               2024-06-03 1.0.18
               2024-06-04 1.0.19
+              2024-06-13 1.0.20
 ===================================
 */
 
@@ -744,10 +745,7 @@ Version Date: 2023-03-08 1.0.1
         proc datasets noprint nowarn;
             delete tmp_qualify_indata
                    tmp_qualify_indata_unique_total
-                   %if %sysmexecdepth < 2 %then %do;
-                       tmp_qualify_indata_unique_var
-                   %end;
-                   %else %if not (%sysmexecname(%sysmexecdepth - 2) = QUALIFY_MULTI_TEST) %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique_var*/
+                   %if not (%sysmexecname(%sysmexecdepth - 2) = QUALIFY_MULTI_TEST) %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique_var*/
                        tmp_qualify_indata_unique_var
                    %end;
                    tmp_qualify_by_fmt

--- a/utf8/qualify_multi.sas
+++ b/utf8/qualify_multi.sas
@@ -11,6 +11,7 @@ Version Date: 2023-12-26 0.1
               2024-04-25 0.6
               2024-04-25 0.7
               2024-06-04 0.8
+              2024-06-13 0.9
 ===================================
 */
 
@@ -303,10 +304,10 @@ Version Date: 2023-12-26 0.1
         %goto exit_with_error;
     %end;
 
-    %if %sysmexecname(%sysmexecdepth - 1) = QUALIFY_MULTI_TEST %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique*/
+    %if %sysmexecname(%sysmexecdepth - 1) = QUALIFY_MULTI_TEST %then %do; /*如果被 %qualify_multi_test 调用，则保留数据集 tmp_qualify_indata_unique_var*/
         proc datasets library = work noprint nowarn;
-            delete tmp_qmt_indata_unique;
-            change tmp_qualify_indata_unique = tmp_qmt_indata_unique;
+            delete tmp_qmt_indata_unique_var;
+            change tmp_qualify_indata_unique_var = tmp_qmt_indata_unique_var;
         quit;
     %end;
 

--- a/utf8/qualify_multi_test.sas
+++ b/utf8/qualify_multi_test.sas
@@ -11,6 +11,7 @@ Version Date: 2024-01-08 0.1
               2024-04-28 0.6
               2024-06-03 0.7
               2024-06-04 0.8
+              2024-06-13 0.9
 ===================================
 */
 
@@ -289,7 +290,7 @@ Version Date: 2024-01-08 0.1
     %end;
 
     /*卡方和Fisher精确检验*/
-    proc freq data = tmp_qualify_indata_unique_var noprint;
+    proc freq data = tmp_qmt_indata_unique_var noprint;
         tables &var_name*&group_var /chisq(warn = (output nolog)) fisher;
         output out = tmp_qmt_chisq chisq;
     run;
@@ -374,13 +375,13 @@ Version Date: 2024-01-08 0.1
     %if &DEL_TEMP_DATA = TRUE %then %do;
         proc datasets noprint nowarn;
             delete tmp_qmt_indata
-                   tmp_qmt_indata_unique
+                   tmp_qmt_indata_unique_var
                    tmp_qmt_desc
                    tmp_qmt_stat
                    tmp_qmt_outdata
                    tmp_qmt_chisq
 
-                   tmp_qualify_indata_unique /*%qualify_multi 拆分 group 各水平调用 %qualify 残留的数据集*/
+                   tmp_qualify_indata_unique_var /*%qualify_multi 拆分 group 各水平调用 %qualify 残留的数据集*/
                    ;
         quit;
     %end;


### PR DESCRIPTION
数据集 tmp_qualify_indata_unique_var 根据 uid 和指定的分析变量进行去重，它将用于卡方统计量和 P 值的计算。