### PR TITLE
fix(crosstab): 计算 `item` 列长度时未考虑 `rowcat_missing = true` 和 `rowcat_total = true` 的影响

### DIFF
--- a/src/gb18030/crosstab.sas
+++ b/src/gb18030/crosstab.sas
@@ -249,6 +249,16 @@
         %end;
     %end;
 
+    /*rowcat_missing*/
+    %if %superq(rowcat_missing) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(È±Ê§), &rowcat_len_max));
+    %end;
+
+    /*rowcat_total*/
+    %if %superq(rowcat_total) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(ºÏ¼Æ), &rowcat_len_max));
+    %end;
+
     /*¸´ÖÆ indata*/
     data tmp_indata;
         set %superq(indata);

--- a/src/gb2312/crosstab.sas
+++ b/src/gb2312/crosstab.sas
@@ -249,6 +249,16 @@
         %end;
     %end;
 
+    /*rowcat_missing*/
+    %if %superq(rowcat_missing) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(È±Ê§), &rowcat_len_max));
+    %end;
+
+    /*rowcat_total*/
+    %if %superq(rowcat_total) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(ºÏ¼Æ), &rowcat_len_max));
+    %end;
+
     /*¸´ÖÆ indata*/
     data tmp_indata;
         set %superq(indata);

--- a/src/gbk/crosstab.sas
+++ b/src/gbk/crosstab.sas
@@ -249,6 +249,16 @@
         %end;
     %end;
 
+    /*rowcat_missing*/
+    %if %superq(rowcat_missing) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(È±Ê§), &rowcat_len_max));
+    %end;
+
+    /*rowcat_total*/
+    %if %superq(rowcat_total) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(ºÏ¼Æ), &rowcat_len_max));
+    %end;
+
     /*¸´ÖÆ indata*/
     data tmp_indata;
         set %superq(indata);

--- a/src/utf8/crosstab.sas
+++ b/src/utf8/crosstab.sas
@@ -249,6 +249,16 @@
         %end;
     %end;
 
+    /*rowcat_missing*/
+    %if %superq(rowcat_missing) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(缺失), &rowcat_len_max));
+    %end;
+
+    /*rowcat_total*/
+    %if %superq(rowcat_total) = TRUE %then %do;
+        %let rowcat_len_max = %sysfunc(max(%length(合计), &rowcat_len_max));
+    %end;
+
     /*复制 indata*/
     data tmp_indata;
         set %superq(indata);


### PR DESCRIPTION
…tal = true` 的影响