### PR TITLE
fix(crosstab): `arm_by` 指定的 format 未定义时，程序未能正常结束

### DIFF
--- a/src/gb18030/crosstab.sas
+++ b/src/gb18030/crosstab.sas
@@ -215,6 +215,10 @@
                 proc sql noprint;
                     select libname, memname, source into :arm_by_fmt_libname, :arm_by_fmt_memname, :arm_by_fmt_source from dictionary.formats where fmtname = "&arm_by_fmt";
                 quit;
+                %if &sqlobs = 0 %then %do;
+                    %put ERROR: (ARM_BY) &arm_by_fmt Œ¥∂®“Â£°;
+                    %goto exit;
+                %end;
 
                 proc format library = &arm_by_fmt_libname..&arm_by_fmt_memname cntlout = tmp_arm_by_fmt;
                     select &arm_by_fmt;

--- a/src/gb2312/crosstab.sas
+++ b/src/gb2312/crosstab.sas
@@ -215,6 +215,10 @@
                 proc sql noprint;
                     select libname, memname, source into :arm_by_fmt_libname, :arm_by_fmt_memname, :arm_by_fmt_source from dictionary.formats where fmtname = "&arm_by_fmt";
                 quit;
+                %if &sqlobs = 0 %then %do;
+                    %put ERROR: (ARM_BY) &arm_by_fmt Œ¥∂®“Â£°;
+                    %goto exit;
+                %end;
 
                 proc format library = &arm_by_fmt_libname..&arm_by_fmt_memname cntlout = tmp_arm_by_fmt;
                     select &arm_by_fmt;

--- a/src/gbk/crosstab.sas
+++ b/src/gbk/crosstab.sas
@@ -215,6 +215,10 @@
                 proc sql noprint;
                     select libname, memname, source into :arm_by_fmt_libname, :arm_by_fmt_memname, :arm_by_fmt_source from dictionary.formats where fmtname = "&arm_by_fmt";
                 quit;
+                %if &sqlobs = 0 %then %do;
+                    %put ERROR: (ARM_BY) &arm_by_fmt Œ¥∂®“Â£°;
+                    %goto exit;
+                %end;
 
                 proc format library = &arm_by_fmt_libname..&arm_by_fmt_memname cntlout = tmp_arm_by_fmt;
                     select &arm_by_fmt;

--- a/src/utf8/crosstab.sas
+++ b/src/utf8/crosstab.sas
@@ -215,6 +215,10 @@
                 proc sql noprint;
                     select libname, memname, source into :arm_by_fmt_libname, :arm_by_fmt_memname, :arm_by_fmt_source from dictionary.formats where fmtname = "&arm_by_fmt";
                 quit;
+                %if &sqlobs = 0 %then %do;
+                    %put ERROR: (ARM_BY) &arm_by_fmt 未定义！;
+                    %goto exit;
+                %end;
 
                 proc format library = &arm_by_fmt_libname..&arm_by_fmt_memname cntlout = tmp_arm_by_fmt;
                     select &arm_by_fmt;


### PR DESCRIPTION
- #109 